### PR TITLE
修复关键 bug 并迁移到 PyTorch 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.pth.tar
+checkpoints/
+logs/
+submit/
+data/
+aug/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,94 +1,131 @@
-### 声明：开源只是为了方便大家交流学习，数据请勿用于商业用途！！！！转载或解读请注明出处，谢谢！
+# 农作物病害检测 (Plants Disease Detection)
 
-**背景**
+> AI Challenger 2018 [农作物病害检测](https://challenger.ai/competition/pdr2018) 竞赛 baseline，基于 PyTorch 的图像分类方案。
+>
+> **声明**：开源仅供交流学习，数据请勿用于商业用途。转载或解读请注明出处，谢谢！
 
-很早之前开源过 pytorch 进行图像分类的代码（[从实例掌握 pytorch 进行图像分类](http://spytensor.com/index.php/archives/21/)），历时两个多月的学习和总结，近期也做了升级。在此基础上写了一个 Ai Challenger 农作物竞赛的 baseline 供大家交流。
+**成绩**：线上 0.8805，线下 0.875（因划分存在随机性，复现可能有波动，已尽量固定随机种子）。
 
-**2018 年 12 月 13 日更新**
+---
 
-新增数据集下载链接：[百度网盘]( https://pan.baidu.com/s/16f1nQchS-zBtzSWn9Guyyg ) 提取码：iksk 
-数据集是 10 月 23 日 更新后的新数据集，包含训练集、验证集、测试集A/B.
-另外最近有同学拿到类似的数据，想做分类的任务，但是这份代码是针对这次比赛开源的，在数据读取方式上会有区别，对于新手来说不太友好，我开源了一份针对图像分类任务的代码，并附上简单教程，相信看完后能比较轻松使用 pytorch 进行图像分类。
+## 目录
 
-教程: [从实例掌握 pytorch 进行图像分类](http://www.spytensor.com/index.php/archives/21/)
+- [环境依赖](#环境依赖)
+- [数据准备](#数据准备)
+- [使用方法](#使用方法)
+- [方案说明](#方案说明)
+- [项目结构](#项目结构)
+- [2026 现代化改造记录](#2026-现代化改造记录)
+- [相关链接](#相关链接)
 
-代码: [pytorch-image-classification](https://github.com/spytensor/pytorch-image-classification)
+---
 
-**2018年 10 月 30 日更新**
+## 环境依赖
 
-新增 `data_aug.py` 用于线下数据增强，由于时间问题，这个比赛不再做啦，这些增强方式大家有需要可以研究一下，支持的增强方式：
+代码已从原始的 `python3.6 / pytorch0.4.1` 迁移到 **PyTorch 2.x**，并支持 **CPU / GPU 自动切换**与**混合精度 (AMP)**。
 
-- 高斯噪声
-- 亮度变化
-- 左右翻转
-- 上下翻转
-- 色彩抖动
-- 对比度变化
-- 锐度变化
+```bash
+pip install -r requirements.txt
+```
 
-注：对比度增强在可视化后，主观感觉特征更明显了，目前我还未跑完。提醒一下，如果做了对比度增强，在测试集的时候最好也做一下。
+主要依赖：
 
-个人博客：[超杰](http://spytensor.com/)
+| 包 | 版本要求 |
+| --- | --- |
+| python | >= 3.8 |
+| torch | >= 2.0 |
+| torchvision | >= 0.15 |
+| scikit-learn | 用于分层划分 |
+| pandas / numpy | 数据处理 |
+| pillow / opencv-python / scikit-image | 图像与离线增强 |
+| tqdm | 进度条 |
 
-比赛地址：[农作物病害检测](https://challenger.ai/competition/pdr2018)
+运行设备在 [`config.py`](config.py) 中自动探测：有 GPU 时用 CUDA + AMP，无 GPU 时回退到 CPU。
 
-完整代码地址：[plants_disease_detection](https://github.com/spytensor/plants_disease_detection)
+## 数据准备
 
-    注：
-    欢迎大佬学习交流啊，这份代码可改进的地方太多了,
-    如果大佬们有啥改进的意见请指导！
-    联系方式：zhuchaojie@buaa.edu.cn
+1. 下载数据集（10 月 23 日更新后的新版，含训练/验证/测试 A、B）：
+   [百度网盘](https://pan.baidu.com/s/16f1nQchS-zBtzSWn9Guyyg)，提取码：`iksk`
+2. 将**测试集**图片复制到 `data/test/` 下。
+3. 将**训练集 + 验证集**的图片都复制到 `data/temp/images/`，两个 `json` 标注文件放到 `data/temp/labels/`。
+4. 执行 `move.py` 按类别整理图片到 `data/train/<类别>/`：
 
-**成绩**：线上 0.8805，线下0.875，由于划分存在随机性，可能复现会出现波动，已经尽可能排除随机种子的干扰了。
+   ```bash
+   python move.py
+   ```
 
-## 提醒
+   > 该脚本会删除样本异常的第 44、45 类，并把之后的类别编号整体前移 2 位（`num_classes` 因此为 59）。`main.py` 的 `test()` 会做逆映射，把预测结果还原回官方原始编号。
 
-`main.py` 中的test函数已经修正，执行后在 `./submit/`中会得到提交格式的 json 文件,现已支持 Focalloss 和交叉验证，需要的自行修改一下就可以了。
-依赖中的 pytorch 版本请保持一致，不然可能会有一些小 BUG。
+## 使用方法
 
-### 1. 依赖
+```bash
+# 训练 + 在测试集上推理，生成提交文件
+python main.py
+```
 
-    python3.6 pytorch0.4.1
+- 训练日志写入 `logs/log_train.txt`；
+- 权重保存在 `checkpoints/`，最优模型在 `checkpoints/best_model/`；
+- 训练结束后自动加载最优模型对测试集推理，结果写入 `submit/baseline.json`（官方提交格式）。
 
-### 2. 关于数据的处理
+关键超参数（在 [`config.py`](config.py) 中调整）：
 
-首先说明，使用的数据为官方更新后的数据，并做了一个统计分析（下文会给出），最后决定删除第 44 类和第 45 类。
-并且由于数据分布的原因，我将 train 和 val 数据集合并后，采用随机划分。
+| 参数 | 默认值 | 说明 |
+| --- | --- | --- |
+| `epochs` | 40 | 训练轮数 |
+| `batch_size` | 8 | 650×650 大图较吃显存，按需调整 |
+| `img_height/img_width` | 650 | 输入尺寸 |
+| `lr` | 1e-4 | Adam 学习率 |
+| `use_amp` | True | 混合精度（仅 CUDA 生效） |
+| `use_focal_loss` | False | 置 True 改用（已修复的）FocalLoss |
 
-数据增强方式：
+## 方案说明
 
-- RandomRotation(30)
-- RandomHorizontalFlip()
-- RandomVerticalFlip()
-- RandomAffine(45)
+- **模型**：ResNet50（ImageNet 预训练），替换全局池化为 `AdaptiveAvgPool2d(1)` 并接 59 类分类头。
+- **数据划分**：合并 train/val 后用 `StratifiedKFold` 思路做分层随机划分（`test_size=0.15`）。
+- **数据增强**（在线，见 [`dataset/dataloader.py`](dataset/dataloader.py)）：
+  `RandomRotation(30)`、`RandomHorizontalFlip`、`RandomVerticalFlip`、`RandomAffine(45)`。
+- **离线增强**（可选，见 [`data_aug.py`](data_aug.py)）：高斯噪声、亮度/对比度变化、翻转等。
+- **优化器**：Adam（`amsgrad=True`），`StepLR`（每 10 epoch × 0.1）。
+- **损失**：默认 `CrossEntropyLoss`，可切换 FocalLoss。
 
-图片尺寸选择了 650，暂时没有对这个尺寸进行调优（毕竟太忙了。。）
+## 项目结构
 
-### 3. 模型选择
+```
+.
+├── config.py              # 全部超参数、设备与开关
+├── move.py                # 按标注把图片整理进类别目录
+├── data_aug.py            # 离线数据增强（可选）
+├── dataset/dataloader.py  # Dataset / DataLoader / transforms
+├── models/model.py        # ResNet50 分类网络
+├── utils.py               # AverageMeter / accuracy / Logger / FocalLoss 等
+└── main.py                # 训练、评估、测试主流程
+```
 
-模型目前就尝试了 resnet50，后续有卡的话再说吧。。。
+## 2026 现代化改造记录
 
-### 4. 超参数设置
+在原 2018 版基础上做了如下修复与升级：
 
-详情在 config.py 中
+**Bug 修复**
+- **FocalLoss 数学错误**：原实现对 batch 平均后的标量做加权，退化成普通交叉熵。现改为 `reduction='none'` 逐样本计算调制因子 `(1-pt)^γ`，并支持 `mean/sum/none`。
+- **删除坏掉的 `DenseModel`**：forward 里定义了却未使用的层、写死的 pool 尺寸、`sigmoid` + `CrossEntropyLoss` 双重激活等问题，整体移除（训练本就走 `get_net`）。
+- **`data_aug.py` 语法错误**：修复错位的 `try/except` 缩进。
 
-### 5.使用方法
+**PyTorch 2.x 迁移**
+- 移除已废弃的 `torch.autograd.Variable`，改用 `tensor.to(device)`。
+- 预训练加载 `pretrained=True` → `weights=ResNet50_Weights.IMAGENET1K_V1`。
+- `scheduler.step(epoch)` 旧用法 → `scheduler.step()`，并移到 epoch 末尾。
+- `torch.load(..., weights_only=False, map_location=device)` 显式化，兼容新默认值。
+- Pillow 常量 `Image.FLIP_*` → `Image.Transpose.FLIP_*`（新版已移除旧别名）。
 
-- 第一步：将测试集图片复制到 `data/test/` 下
-- 第二步：将训练集合验证集中的图片都复制到 `data/temp/images/` 下，将两个 `json` 文件放到 `data/temp/labels/` 下
-- 执行 move.py 文件
-- 执行 main.py 进行训练
+**新增能力**
+- **CPU / GPU 自动切换**：无显卡也能跑。
+- **混合精度 (AMP)**：`use_amp` 开关，CUDA 上显著省显存、提速。
+- `DataLoader` 增加 `num_workers`，读图统一 `convert("RGB")` 防止灰度/RGBA 崩溃。
+- 修正 `img_weight` → `img_width` 命名及 `Resize` 的 (H, W) 顺序。
 
-### 6.数据分布图
+## 相关链接
 
-训练集
-
-![train](http://www.spytensor.com/images/plants/train.png)
-
-验证集
-
-![val](http://www.spytensor.com/images/plants/val.png)
-
-全部数据集
-
-![all](http://www.spytensor.com/images/plants/all.png)
+- 完整代码：[plants_disease_detection](https://github.com/spytensor/plants_disease_detection)
+- 图像分类入门教程与代码：[从实例掌握 pytorch 进行图像分类](http://www.spytensor.com/index.php/archives/21/) · [pytorch-image-classification](https://github.com/spytensor/pytorch-image-classification)
+- 个人博客：[超杰](http://spytensor.com/)
+- 联系方式：zhuchaojie@buaa.edu.cn

--- a/config.py
+++ b/config.py
@@ -1,5 +1,8 @@
+import torch
+
+
 class DefaultConfigs(object):
-    #1.string parameters
+    # 1. path parameters
     train_data = "./data/train/"
     test_data = "./data/test/"
     val_data = "no"
@@ -8,17 +11,28 @@ class DefaultConfigs(object):
     best_models = weights + "best_model/"
     submit = "./submit/"
     logs = "./logs/"
-    gpus = "1"
 
-    #2.numeric parameters
+    # 2. device parameters
+    # 用哪些 GPU（逗号分隔），设为 "" 则强制 CPU
+    gpus = "0"
+    # 运行设备，自动探测，无 GPU 时回退到 CPU
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    num_workers = 4
+    # 是否启用混合精度（AMP），仅在 CUDA 上生效
+    use_amp = True
+
+    # 3. numeric parameters
     epochs = 40
     batch_size = 8
     img_height = 650
-    img_weight = 650
+    img_width = 650
     num_classes = 59
     seed = 888
     lr = 1e-4
     lr_decay = 1e-4
     weight_decay = 1e-4
+    # 是否使用 FocalLoss（否则用 CrossEntropyLoss）
+    use_focal_loss = False
+
 
 config = DefaultConfigs()

--- a/data_aug.py
+++ b/data_aug.py
@@ -27,11 +27,8 @@ def changeLight(img):
     img = exposure.adjust_gamma(img, rate) #大于1为调暗，小于1为调亮;1.05
     return img
 
-try:
-    for i in range(59):
-        os.makedirs(new_path + os.sep + str(i))
-    except:
-        pass
+for i in range(59):
+    os.makedirs(new_path + os.sep + str(i), exist_ok=True)
 
 for raw_dir_name in range(59):
 
@@ -71,9 +68,9 @@ for raw_dir_name in range(59):
 
         #1.翻转 
 
-        img_flip_left_right = img.transpose(Image.FLIP_LEFT_RIGHT)
+        img_flip_left_right = img.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
 
-        img_flip_top_bottom = img.transpose(Image.FLIP_TOP_BOTTOM)
+        img_flip_top_bottom = img.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
 
         #2.旋转 
 

--- a/dataset/dataloader.py
+++ b/dataset/dataloader.py
@@ -35,13 +35,13 @@ class ChaojieDataset(Dataset):
         if transforms is None:
             if self.test or not train:
                 self.transforms = T.Compose([
-                    T.Resize((config.img_weight,config.img_height)),
+                    T.Resize((config.img_height,config.img_width)),
                     T.ToTensor(),
                     T.Normalize(mean = [0.485,0.456,0.406],
                                 std = [0.229,0.224,0.225])])
             else:
                 self.transforms  = T.Compose([
-                    T.Resize((config.img_weight,config.img_height)),
+                    T.Resize((config.img_height,config.img_width)),
                     T.RandomRotation(30),
                     T.RandomHorizontalFlip(),
                     T.RandomVerticalFlip(),
@@ -54,12 +54,12 @@ class ChaojieDataset(Dataset):
     def __getitem__(self,index):
         if self.test:
             filename = self.imgs[index]
-            img = Image.open(filename)
+            img = Image.open(filename).convert("RGB")
             img = self.transforms(img)
             return img,filename
         else:
             filename,label = self.imgs[index] 
-            img = Image.open(filename)
+            img = Image.open(filename).convert("RGB")
             img = self.transforms(img)
             return img,label
     def __len__(self):

--- a/main.py
+++ b/main.py
@@ -1,255 +1,212 @@
-import os 
-import random 
+import os
+import random
 import time
 import json
 import torch
-import torchvision
-import numpy as np 
-import pandas as pd 
+import numpy as np
+import pandas as pd
 import warnings
 from datetime import datetime
-from torch import nn,optim
-from config import config 
+from torch import nn, optim
+from config import config
 from collections import OrderedDict
-from torch.autograd import Variable 
 from torch.utils.data import DataLoader
 from dataset.dataloader import *
-from sklearn.model_selection import train_test_split,StratifiedKFold
+from sklearn.model_selection import train_test_split
 from timeit import default_timer as timer
 from models.model import *
 from utils import *
 
-#1. set random.seed and cudnn performance
+# 1. set random seed and device
 random.seed(config.seed)
 np.random.seed(config.seed)
 torch.manual_seed(config.seed)
-torch.cuda.manual_seed_all(config.seed)
-os.environ["CUDA_VISIBLE_DEVICES"] = config.gpus
-torch.backends.cudnn.benchmark = True
+
+device = torch.device(config.device)
+if device.type == "cuda":
+    os.environ["CUDA_VISIBLE_DEVICES"] = config.gpus
+    torch.cuda.manual_seed_all(config.seed)
+    torch.backends.cudnn.benchmark = True
+
+use_amp = config.use_amp and device.type == "cuda"
 warnings.filterwarnings('ignore')
 
-#2. evaluate func
-def evaluate(val_loader,model,criterion):
-    #2.1 define meters
+
+# 2. evaluate func
+def evaluate(val_loader, model, criterion):
+    # 2.1 define meters
     losses = AverageMeter()
     top1 = AverageMeter()
     top2 = AverageMeter()
-    #2.2 switch to evaluate mode and confirm model has been transfered to cuda
-    model.cuda()
+    # 2.2 switch to evaluate mode
     model.eval()
     with torch.no_grad():
-        for i,(input,target) in enumerate(val_loader):
-            input = Variable(input).cuda()
-            target = Variable(torch.from_numpy(np.array(target)).long()).cuda()
-            #target = Variable(target).cuda()
-            #2.2.1 compute output
-            output = model(input)
-            loss = criterion(output,target)
+        for i, (input, target) in enumerate(val_loader):
+            input = input.to(device)
+            target = torch.as_tensor(target, dtype=torch.long, device=device)
+            with torch.autocast(device_type=device.type, enabled=use_amp):
+                output = model(input)
+                loss = criterion(output, target)
 
-            #2.2.2 measure accuracy and record loss
-            precision1,precision2 = accuracy(output,target,topk=(1,2))
-            losses.update(loss.item(),input.size(0))
-            top1.update(precision1[0],input.size(0))
-            top2.update(precision2[0],input.size(0))
+            # 2.2.1 measure accuracy and record loss
+            precision1, precision2 = accuracy(output, target, topk=(1, 2))
+            losses.update(loss.item(), input.size(0))
+            top1.update(precision1[0].item(), input.size(0))
+            top2.update(precision2[0].item(), input.size(0))
 
-    return [losses.avg,top1.avg,top2.avg]
+    return [losses.avg, top1.avg, top2.avg]
 
-#3. test model on public dataset and save the probability matrix
-def test(test_loader,model,folds):
-    #3.1 confirm the model converted to cuda
-    csv_map = OrderedDict({"filename":[],"probability":[]})
-    model.cuda()
+
+# 3. test model on public dataset and save the probability matrix
+def test(test_loader, model, folds):
+    csv_map = OrderedDict({"filename": [], "probability": []})
     model.eval()
-    with open("./submit/baseline.json","w",encoding="utf-8") as f :
+    with open("./submit/baseline.json", "w", encoding="utf-8") as f:
         submit_results = []
-        for i,(input,filepath) in enumerate(tqdm(test_loader)):
-            #3.2 change everything to cuda and get only basename
+        for i, (input, filepath) in enumerate(tqdm(test_loader)):
+            # 只保留文件名
             filepath = [os.path.basename(x) for x in filepath]
             with torch.no_grad():
-                image_var = Variable(input).cuda()
-                #3.3.output
-                #print(filepath)
-                #print(input,input.shape)
-                y_pred = model(image_var)
-                #print(y_pred.shape)
-                smax = nn.Softmax(1)
-                smax_out = smax(y_pred)
-            #3.4 save probability to csv files
+                image_var = input.to(device)
+                with torch.autocast(device_type=device.type, enabled=use_amp):
+                    y_pred = model(image_var)
+                    smax_out = nn.functional.softmax(y_pred, dim=1)
+            # 保存每张图的概率向量
             csv_map["filename"].extend(filepath)
             for output in smax_out:
                 prob = ";".join([str(i) for i in output.data.tolist()])
                 csv_map["probability"].append(prob)
         result = pd.DataFrame(csv_map)
-        result["probability"] = result["probability"].map(lambda x : [float(i) for i in x.split(";")])
+        result["probability"] = result["probability"].map(lambda x: [float(i) for i in x.split(";")])
         for index, row in result.iterrows():
             pred_label = np.argmax(row['probability'])
+            # move.py 中删除了原始的 44、45 两类并把 >45 的类别 -2，
+            # 这里做逆映射把预测类别还原回官方原始编号：>=44 的 +2
             if pred_label > 43:
                 pred_label = pred_label + 2
-            submit_results.append({"image_id":row['filename'],"disease_class":pred_label})
-        json.dump(submit_results,f,ensure_ascii=False,cls = MyEncoder)
+            submit_results.append({"image_id": row['filename'], "disease_class": pred_label})
+        json.dump(submit_results, f, ensure_ascii=False, cls=MyEncoder)
 
-#4. more details to build main function    
+
+# 4. main function
 def main():
     fold = 0
-    #4.1 mkdirs
-    if not os.path.exists(config.submit):
-        os.mkdir(config.submit)
-    if not os.path.exists(config.weights):
-        os.mkdir(config.weights)
-    if not os.path.exists(config.best_models):
-        os.mkdir(config.best_models)
-    if not os.path.exists(config.logs):
-        os.mkdir(config.logs)
-    if not os.path.exists(config.weights + config.model_name + os.sep +str(fold) + os.sep):
-        os.makedirs(config.weights + config.model_name + os.sep +str(fold) + os.sep)
-    if not os.path.exists(config.best_models + config.model_name + os.sep +str(fold) + os.sep):
-        os.makedirs(config.best_models + config.model_name + os.sep +str(fold) + os.sep)       
-    #4.2 get model and optimizer
+    # 4.1 mkdirs
+    for d in [config.submit, config.weights, config.best_models, config.logs]:
+        os.makedirs(d, exist_ok=True)
+    os.makedirs(config.weights + config.model_name + os.sep + str(fold) + os.sep, exist_ok=True)
+    os.makedirs(config.best_models + config.model_name + os.sep + str(fold) + os.sep, exist_ok=True)
+
+    # 4.2 get model, optimizer, criterion
     model = get_net()
-    #model = torch.nn.DataParallel(model)
-    model.cuda()
-    #optimizer = optim.SGD(model.parameters(),lr = config.lr,momentum=0.9,weight_decay=config.weight_decay)
-    optimizer = optim.Adam(model.parameters(),lr = config.lr,amsgrad=True,weight_decay=config.weight_decay)
-    criterion = nn.CrossEntropyLoss().cuda()
-    #criterion = FocalLoss().cuda()
+    model.to(device)
+    optimizer = optim.Adam(model.parameters(), lr=config.lr, amsgrad=True, weight_decay=config.weight_decay)
+    if config.use_focal_loss:
+        criterion = FocalLoss().to(device)
+    else:
+        criterion = nn.CrossEntropyLoss().to(device)
+    scaler = torch.cuda.amp.GradScaler(enabled=use_amp)
+
     log = Logger()
-    log.open(config.logs + "log_train.txt",mode="a")
+    log.open(config.logs + "log_train.txt", mode="a")
     log.write("\n----------------------------------------------- [START %s] %s\n\n" % (datetime.now().strftime('%Y-%m-%d %H:%M:%S'), '-' * 51))
-    #4.3 some parameters for  K-fold and restart model
+
+    # 4.3 params for restart
     start_epoch = 0
     best_precision1 = 0
     best_precision_save = 0
     resume = False
-    
-    #4.4 restart the training process
+
+    # 4.4 restart the training process
     if resume:
-        checkpoint = torch.load(config.best_models + str(fold) + "/model_best.pth.tar")
+        checkpoint = torch.load(config.best_models + str(fold) + "/model_best.pth.tar", map_location=device, weights_only=False)
         start_epoch = checkpoint["epoch"]
         fold = checkpoint["fold"]
         best_precision1 = checkpoint["best_precision1"]
         model.load_state_dict(checkpoint["state_dict"])
         optimizer.load_state_dict(checkpoint["optimizer"])
 
-    #4.5 get files and split for K-fold dataset
-    #4.5.1 read files
-    train_ = get_files(config.train_data,"train")
-    #val_data_list = get_files(config.val_data,"val")
-    test_files = get_files(config.test_data,"test")
+    # 4.5 get files and split
+    train_ = get_files(config.train_data, "train")
+    test_files = get_files(config.test_data, "test")
 
-    """ 
-    #4.5.2 split
-    split_fold = StratifiedKFold(n_splits=3)
-    folds_indexes = split_fold.split(X=origin_files["filename"],y=origin_files["label"])
-    folds_indexes = np.array(list(folds_indexes))
-    fold_index = folds_indexes[fold]
+    train_data_list, val_data_list = train_test_split(train_, test_size=0.15, stratify=train_["label"], random_state=config.seed)
+    # 4.5.4 load dataset
+    train_dataloader = DataLoader(ChaojieDataset(train_data_list), batch_size=config.batch_size, shuffle=True, collate_fn=collate_fn, pin_memory=True, num_workers=config.num_workers)
+    val_dataloader = DataLoader(ChaojieDataset(val_data_list, train=False), batch_size=config.batch_size, shuffle=False, collate_fn=collate_fn, pin_memory=False, num_workers=config.num_workers)
+    test_dataloader = DataLoader(ChaojieDataset(test_files, test=True), batch_size=1, shuffle=False, pin_memory=False, num_workers=config.num_workers)
+    scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=10, gamma=0.1)
 
-    #4.5.3 using fold index to split for train data and val data
-    train_data_list = pd.concat([origin_files["filename"][fold_index[0]],origin_files["label"][fold_index[0]]],axis=1)
-    val_data_list = pd.concat([origin_files["filename"][fold_index[1]],origin_files["label"][fold_index[1]]],axis=1)
-    """
-    train_data_list,val_data_list = train_test_split(train_,test_size = 0.15,stratify=train_["label"])
-    #4.5.4 load dataset
-    train_dataloader = DataLoader(ChaojieDataset(train_data_list),batch_size=config.batch_size,shuffle=True,collate_fn=collate_fn,pin_memory=True)
-    val_dataloader = DataLoader(ChaojieDataset(val_data_list,train=False),batch_size=config.batch_size,shuffle=True,collate_fn=collate_fn,pin_memory=False)
-    test_dataloader = DataLoader(ChaojieDataset(test_files,test=True),batch_size=1,shuffle=False,pin_memory=False)
-    #scheduler = optim.lr_scheduler.ReduceLROnPlateau(optimizer,"max",verbose=1,patience=3)
-    scheduler =  optim.lr_scheduler.StepLR(optimizer,step_size = 10,gamma=0.1)
-    #4.5.5.1 define metrics
+    # 4.5.5.1 define metrics
     train_losses = AverageMeter()
     train_top1 = AverageMeter()
     train_top2 = AverageMeter()
-    valid_loss = [np.inf,0,0]
+    valid_loss = [np.inf, 0, 0]
     model.train()
-    #logs
+    # logs
     log.write('** start training here! **\n')
     log.write('                           |------------ VALID -------------|----------- TRAIN -------------|------Accuracy------|------------|\n')
     log.write('lr       iter     epoch    | loss   top-1  top-2            | loss   top-1  top-2           |    Current Best    | time       |\n')
     log.write('-------------------------------------------------------------------------------------------------------------------------------\n')
-    #4.5.5 train
+    # 4.5.5 train
     start = timer()
-    for epoch in range(start_epoch,config.epochs):
-        scheduler.step(epoch)
+    for epoch in range(start_epoch, config.epochs):
         # train
-        #global iter
-        for iter,(input,target) in enumerate(train_dataloader):
-            #4.5.5 switch to continue train process
+        for iter, (input, target) in enumerate(train_dataloader):
             model.train()
-            input = Variable(input).cuda()
-            target = Variable(torch.from_numpy(np.array(target)).long()).cuda()
-            #target = Variable(target).cuda()
-            output = model(input)
-            loss = criterion(output,target)
+            input = input.to(device)
+            target = torch.as_tensor(target, dtype=torch.long, device=device)
+            with torch.autocast(device_type=device.type, enabled=use_amp):
+                output = model(input)
+                loss = criterion(output, target)
 
-            precision1_train,precision2_train = accuracy(output,target,topk=(1,2))
-            train_losses.update(loss.item(),input.size(0))
-            train_top1.update(precision1_train[0],input.size(0))
-            train_top2.update(precision2_train[0],input.size(0))
-            #backward
+            precision1_train, precision2_train = accuracy(output, target, topk=(1, 2))
+            train_losses.update(loss.item(), input.size(0))
+            train_top1.update(precision1_train[0].item(), input.size(0))
+            train_top2.update(precision2_train[0].item(), input.size(0))
+            # backward
             optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
+            scaler.scale(loss).backward()
+            scaler.step(optimizer)
+            scaler.update()
             lr = get_learning_rate(optimizer)
-            print('\r',end='',flush=True)
-            print('%0.4f %5.1f %6.1f        | %0.3f  %0.3f  %0.3f         | %0.3f  %0.3f  %0.3f         |         %s         | %s' % (\
-                         lr, iter/len(train_dataloader) + epoch, epoch,
-                         valid_loss[0], valid_loss[1], valid_loss[2],
-                         train_losses.avg, train_top1.avg, train_top2.avg,str(best_precision_save),
-                         time_to_str((timer() - start),'min'))
-            , end='',flush=True)
-        #evaluate
+            print('\r', end='', flush=True)
+            print('%0.4f %5.1f %6.1f        | %0.3f  %0.3f  %0.3f         | %0.3f  %0.3f  %0.3f         |         %s         | %s' % (
+                lr, iter / len(train_dataloader) + epoch, epoch,
+                valid_loss[0], valid_loss[1], valid_loss[2],
+                train_losses.avg, train_top1.avg, train_top2.avg, str(best_precision_save),
+                time_to_str((timer() - start), 'min'))
+                , end='', flush=True)
+        # StepLR 按 epoch 更新，放在 epoch 末尾、不再传 epoch 参数（旧用法已废弃）
+        scheduler.step()
+        # evaluate
         lr = get_learning_rate(optimizer)
-        #evaluate every half epoch
-        valid_loss = evaluate(val_dataloader,model,criterion)
+        valid_loss = evaluate(val_dataloader, model, criterion)
         is_best = valid_loss[1] > best_precision1
-        best_precision1 = max(valid_loss[1],best_precision1)
-        try:
-            best_precision_save = best_precision1.cpu().data.numpy()
-        except:
-            pass
+        best_precision1 = max(valid_loss[1], best_precision1)
+        best_precision_save = best_precision1
         save_checkpoint({
-                    "epoch":epoch + 1,
-                    "model_name":config.model_name,
-                    "state_dict":model.state_dict(),
-                    "best_precision1":best_precision1,
-                    "optimizer":optimizer.state_dict(),
-                    "fold":fold,
-                    "valid_loss":valid_loss,
-        },is_best,fold)
-        #adjust learning rate
-        #scheduler.step(valid_loss[1])
-        print("\r",end="",flush=True)
-        log.write('%0.4f %5.1f %6.1f        | %0.3f  %0.3f  %0.3f          | %0.3f  %0.3f  %0.3f         |         %s         | %s' % (\
-                        lr, 0 + epoch, epoch,
-                        valid_loss[0], valid_loss[1], valid_loss[2],
-                        train_losses.avg,    train_top1.avg,    train_top2.avg, str(best_precision_save),
-                        time_to_str((timer() - start),'min'))
-                )
+            "epoch": epoch + 1,
+            "model_name": config.model_name,
+            "state_dict": model.state_dict(),
+            "best_precision1": best_precision1,
+            "optimizer": optimizer.state_dict(),
+            "fold": fold,
+            "valid_loss": valid_loss,
+        }, is_best, fold)
+        print("\r", end="", flush=True)
+        log.write('%0.4f %5.1f %6.1f        | %0.3f  %0.3f  %0.3f          | %0.3f  %0.3f  %0.3f         |         %s         | %s' % (
+            lr, 0 + epoch, epoch,
+            valid_loss[0], valid_loss[1], valid_loss[2],
+            train_losses.avg, train_top1.avg, train_top2.avg, str(best_precision_save),
+            time_to_str((timer() - start), 'min'))
+        )
         log.write('\n')
         time.sleep(0.01)
-    best_model = torch.load(config.best_models + os.sep+config.model_name+os.sep+ str(fold) +os.sep+ 'model_best.pth.tar')
+    best_model = torch.load(config.best_models + os.sep + config.model_name + os.sep + str(fold) + os.sep + 'model_best.pth.tar', map_location=device, weights_only=False)
     model.load_state_dict(best_model["state_dict"])
-    test(test_dataloader,model,fold)
+    test(test_dataloader, model, fold)
 
-if __name__ =="__main__":
+
+if __name__ == "__main__":
     main()
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/models/model.py
+++ b/models/model.py
@@ -1,44 +1,12 @@
 import torchvision
-import torch.nn.functional as F 
 from torch import nn
+from torchvision.models import ResNet50_Weights
 from config import config
 
-def generate_model():
-    class DenseModel(nn.Module):
-        def __init__(self, pretrained_model):
-            super(DenseModel, self).__init__()
-            self.classifier = nn.Linear(pretrained_model.classifier.in_features, config.num_classes)
-
-            for m in self.modules():
-                if isinstance(m, nn.Conv2d):
-                    nn.init.kaiming_normal(m.weight)
-                elif isinstance(m, nn.BatchNorm2d):
-                    m.weight.data.fill_(1)
-                    m.bias.data.zero_()
-                elif isinstance(m, nn.Linear):
-                    m.bias.data.zero_()
-
-            self.features = pretrained_model.features
-            self.layer1 = pretrained_model.features._modules['denseblock1']
-            self.layer2 = pretrained_model.features._modules['denseblock2']
-            self.layer3 = pretrained_model.features._modules['denseblock3']
-            self.layer4 = pretrained_model.features._modules['denseblock4']
-
-        def forward(self, x):
-            features = self.features(x)
-            out = F.relu(features, inplace=True)
-            out = F.avg_pool2d(out, kernel_size=8).view(features.size(0), -1)
-            out = F.sigmoid(self.classifier(out))
-            return out
-
-    return DenseModel(torchvision.models.densenet169(pretrained=True))
 
 def get_net():
-    #return MyModel(torchvision.models.resnet101(pretrained = True))
-    model = torchvision.models.resnet50(pretrained = True)    
-    #for param in model.parameters():
-    #    param.requires_grad = False
+    # PyTorch 2.x 用 weights= 枚举加载预训练权重，pretrained=True 已废弃
+    model = torchvision.models.resnet50(weights=ResNet50_Weights.IMAGENET1K_V1)
     model.avgpool = nn.AdaptiveAvgPool2d(1)
-    model.fc = nn.Linear(2048,config.num_classes)
+    model.fc = nn.Linear(2048, config.num_classes)
     return model
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+torch>=2.0
+torchvision>=0.15
+numpy
+pandas
+scikit-learn
+pillow
+opencv-python
+scikit-image
+tqdm

--- a/utils.py
+++ b/utils.py
@@ -1,17 +1,20 @@
 import shutil
-import torch
 import sys
 import os
 import json
 import numpy as np
-from config import config
+import torch
 from torch import nn
 import torch.nn.functional as F
-def save_checkpoint(state, is_best,fold):
-    filename = config.weights + config.model_name + os.sep +str(fold) + os.sep + "_checkpoint.pth.tar"
+from config import config
+
+
+def save_checkpoint(state, is_best, fold):
+    filename = config.weights + config.model_name + os.sep + str(fold) + os.sep + "_checkpoint.pth.tar"
     torch.save(state, filename)
     if is_best:
-        shutil.copyfile(filename, config.best_models + config.model_name+ os.sep +str(fold)  + os.sep + 'model_best.pth.tar')
+        shutil.copyfile(filename, config.best_models + config.model_name + os.sep + str(fold) + os.sep + 'model_best.pth.tar')
+
 
 class AverageMeter(object):
     """Computes and stores the average and current value"""
@@ -30,26 +33,6 @@ class AverageMeter(object):
         self.count += n
         self.avg = self.sum / self.count
 
-def adjust_learning_rate(optimizer, epoch):
-    """Sets the learning rate to the initial LR decayed by 10 every 3 epochs"""
-    lr = config.lr * (0.1 ** (epoch // 3))
-    for param_group in optimizer.param_groups:
-        param_group['lr'] = lr
-
-
-def schedule(current_epoch, current_lrs, **logs):
-        lrs = [1e-3, 1e-4, 0.5e-4, 1e-5, 0.5e-5]
-        epochs = [0, 1, 6, 8, 12]
-        for lr, epoch in zip(lrs, epochs):
-            if current_epoch >= epoch:
-                current_lrs[5] = lr
-                if current_epoch >= 2:
-                    current_lrs[4] = lr * 1
-                    current_lrs[3] = lr * 1
-                    current_lrs[2] = lr * 1
-                    current_lrs[1] = lr * 1
-                    current_lrs[0] = lr * 0.1
-        return current_lrs
 
 def accuracy(output, target, topk=(1,)):
     """Computes the accuracy over the k top predictions for the specified values of k"""
@@ -63,26 +46,28 @@ def accuracy(output, target, topk=(1,)):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+            correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 
+
 class Logger(object):
     def __init__(self):
-        self.terminal = sys.stdout  #stdout
+        self.terminal = sys.stdout  # stdout
         self.file = None
 
     def open(self, file, mode=None):
-        if mode is None: mode ='w'
+        if mode is None:
+            mode = 'w'
         self.file = open(file, mode)
 
-    def write(self, message, is_terminal=1, is_file=1 ):
-        if '\r' in message: is_file=0
+    def write(self, message, is_terminal=1, is_file=1):
+        if '\r' in message:
+            is_file = 0
 
         if is_terminal == 1:
             self.terminal.write(message)
             self.terminal.flush()
-            #time.sleep(1)
 
         if is_file == 1:
             self.file.write(message)
@@ -90,59 +75,60 @@ class Logger(object):
 
     def flush(self):
         # this flush method is needed for python 3 compatibility.
-        # this handles the flush command by doing nothing.
-        # you might want to specify some extra behavior here.
         pass
 
+
 def get_learning_rate(optimizer):
-    lr=[]
+    lr = []
     for param_group in optimizer.param_groups:
-       lr +=[ param_group['lr'] ]
-
-    #assert(len(lr)==1) #we support only one param_group
+        lr += [param_group['lr']]
     lr = lr[0]
-
     return lr
 
 
 def time_to_str(t, mode='min'):
-    if mode=='min':
-        t  = int(t)/60
-        hr = t//60
-        min = t%60
-        return '%2d hr %02d min'%(hr,min)
+    if mode == 'min':
+        t = int(t) / 60
+        hr = t // 60
+        min = t % 60
+        return '%2d hr %02d min' % (hr, min)
 
-    elif mode=='sec':
-        t   = int(t)
-        min = t//60
-        sec = t%60
-        return '%2d min %02d sec'%(min,sec)
-
+    elif mode == 'sec':
+        t = int(t)
+        min = t // 60
+        sec = t % 60
+        return '%2d min %02d sec' % (min, sec)
 
     else:
         raise NotImplementedError
 
 
 class FocalLoss(nn.Module):
+    """Focal Loss，逐样本计算难易加权。
 
-    def __init__(self, focusing_param=2, balance_param=0.25):
+    参考 Lin et al., "Focal Loss for Dense Object Detection".
+    关键点：cross_entropy 必须用 reduction='none' 拿到每个样本的 loss，
+    再乘以 (1 - pt) ** gamma 的调制因子，否则退化成普通交叉熵。
+    """
+
+    def __init__(self, gamma=2, alpha=0.25, reduction="mean"):
         super(FocalLoss, self).__init__()
-
-        self.focusing_param = focusing_param
-        self.balance_param = balance_param
+        self.gamma = gamma
+        self.alpha = alpha
+        self.reduction = reduction
 
     def forward(self, output, target):
+        # 逐样本的 -log(pt)
+        logpt = -F.cross_entropy(output, target, reduction="none")
+        pt = torch.exp(logpt)
+        focal_loss = -self.alpha * (1 - pt) ** self.gamma * logpt
 
-        cross_entropy = F.cross_entropy(output, target)
-        cross_entropy_log = torch.log(cross_entropy)
-        logpt = - F.cross_entropy(output, target)
-        pt    = torch.exp(logpt)
+        if self.reduction == "mean":
+            return focal_loss.mean()
+        elif self.reduction == "sum":
+            return focal_loss.sum()
+        return focal_loss
 
-        focal_loss = -((1 - pt) ** self.focusing_param) * logpt
-
-        balanced_focal_loss = self.balance_param * focal_loss
-
-        return balanced_focal_loss
 
 class MyEncoder(json.JSONEncoder):
     def default(self, obj):


### PR DESCRIPTION
八年前的竞赛 baseline，做一次 review 后的修复 + 现代化。

## 🔴 Bug 修复
- **FocalLoss 数学错误**：原实现对 batch 平均后的标量做加权，实际退化成普通交叉熵。改为 `reduction='none'` 逐样本计算调制因子 `(1-pt)^γ`，支持 mean/sum/none。
- **删除坏死的 `DenseModel`**：forward 里有未使用的层、写死的 pool 尺寸、`sigmoid` + `CrossEntropyLoss` 双重激活；训练本就走 `get_net`，整段移除。
- **`data_aug.py` 语法错误**：修复错位的 `try/except` 缩进（原文件直接 `SyntaxError`）。

## 🟡 PyTorch 2.x 迁移
- 移除已废弃的 `torch.autograd.Variable` → `tensor.to(device)`
- `pretrained=True` → `weights=ResNet50_Weights.IMAGENET1K_V1`
- `scheduler.step(epoch)` → `scheduler.step()`（移到 epoch 末尾）
- `torch.load` 显式 `weights_only=False` / `map_location`
- Pillow `Image.FLIP_*` → `Image.Transpose.FLIP_*`（旧别名在 Pillow 10 已移除）

## 🔵 新增能力
- **CPU/GPU 自动切换**，无显卡也能跑
- **AMP 混合精度**（`use_amp` 开关 + `GradScaler`/`autocast`）
- `DataLoader` 加 `num_workers`；读图统一 `.convert("RGB")` 防灰度/RGBA 崩溃
- 修正 `img_weight` → `img_width` 命名及 `Resize` 的 (H, W) 顺序
- 重写 README、新增 `requirements.txt` 与 `.gitignore`

## ✅ 验证
本机 CPU（torch 2.2.2）已验证：全量 `py_compile`、FocalLoss 数值/逐样本形状、ResNet50 分类头输出 `(2, 59)`、AMP API 可用。**未做完整训练**（无数据集/GPU）。